### PR TITLE
ci: add Claude Code reviewer (auto-review + @claude handler)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,78 @@
+name: Claude Code Review
+
+# Automatic review of every human-authored PR. Runs on this public repo's free
+# Actions minutes; Claude usage draws on the maintainer's subscription via
+# CLAUDE_CODE_OAUTH_TOKEN (a repo secret that must be set on this repo — it is
+# NOT inherited from MorphoCloudWorkflow). Re-review after pushing fixes:
+# comment "@claude review" (see claude.yml).
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  review:
+    # Bot PRs (e.g. Dependabot) are skipped — reviewing them is noise.
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. This repo holds MorphoCloud's
+            instance-provisioning Ansible (under `ansible/`), which every cloud
+            instance runs ONCE at first boot via cloud-init, pinned to a specific
+            commit (`exosphere_sha`). A bug here ships to every newly created
+            instance — there is no staging between merge and a user's VM other
+            than the pinned SHA. Focus on what has actually bitten this codebase:
+
+            1. **Ansible correctness (highest value)** — idempotency and re-run
+               safety (`creates:`/`when:` guards, especially the Slicer install
+               on the PERSISTENT volume `/media/volume/MyData`, which survives
+               instance deletion); `loop` failure semantics; `become` /
+               `become_user`; `command` vs `shell`, and whether a task's success
+               is actually detected. We have been bitten by Slicer's
+               `--python-script` exit code being unreliable — success is now
+               detected by grepping stdout for a marker, NOT the exit code.
+            2. **Shell quoting & process control in `shell:`/`command:` tasks** —
+               single-vs-double quotes around `{{ }}` and shell variables,
+               `timeout -k` usage, pipelines whose exit status comes from the
+               wrong command, and `sed`/`grep`/`replace` regex anchors (a
+               `.desktop` `replace` regex once matched both the `Exec` line and
+               the `Slicer.png` `Icon` line).
+            3. **Version / compatibility assumptions** — extension or
+               Python-dependency installs that assume a specific Slicer version
+               or module layout, and anything that would silently leave a
+               headless setup half-done (e.g. an interactive pip prompt that
+               defers instead of installing).
+            4. **Plain bugs** — inverted conditions, wrong paths or variable
+               names, broken placeholder substitution, and tasks that could
+               clobber user data on the persistent volume.
+
+            The upstream Exosphere web client (Elm/JS) also lives in this repo;
+            do NOT review upstream code — focus on MorphoCloud's `ansible/`
+            changes and any cloud-config.
+
+            Report every issue you find, including ones you are uncertain about —
+            include a confidence level and severity for each instead of
+            self-filtering. Use inline comments for specific lines and a
+            top-level comment for overall observations. Do not nitpick style that
+            linters already enforce.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+# On-demand Claude: mention @claude in a PR/issue comment or review to ask for
+# a (re-)review, an explanation, or a change. Restricted to org members and
+# collaborators — this is a public repo, and without the guard any GitHub
+# account could burn the subscription quota (or steer Claude) by commenting.
+# Uses the same CLAUDE_CODE_OAUTH_TOKEN repo secret as claude-code-review.yml.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association) &&
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # lets Claude read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds the same Claude review setup we use in `MorphoCloudWorkflow`, so PRs in this repo (starting with the Slicer 5.12 / ansible work) get reviewed.

- **`claude-code-review.yml`** — auto-review on PR `opened` / `ready_for_review`; skips bot PRs. Prompt is tailored to this repo's **instance-provisioning Ansible** (idempotency / `creates:` guards, `command` vs `shell` and marker-based success detection, shell quoting, `.desktop`/regex anchors, Slicer-version assumptions), and explicitly tells the reviewer to ignore the upstream Exosphere Elm/JS code.
- **`claude.yml`** — on-demand `@claude` (re-)review, gated to `OWNER`/`MEMBER`/`COLLABORATOR`.

### Required before this works — two prerequisites

1. **Add the auth secret to this repo** (it's a repo secret on MorphoCloudWorkflow, not an org secret, so it is not inherited):
   ```
   gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo MorphoCloud/exosphere
   ```
   Paste the same token MorphoCloudWorkflow uses, or generate a fresh one with `claude setup-token`.
2. **Ensure Actions are enabled** for this repo (forks have them off by default): Settings -> Actions -> General -> "Allow all actions".

Once the secret is set and this merges into `welcome`, the next PR (and `@claude review` on it) is reviewed automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)