### PR TITLE
Make individual Slicer extension install failures non-fatal

### DIFF
--- a/ansible/roles/slicer/tasks/main.yml
+++ b/ansible/roles/slicer/tasks/main.yml
@@ -163,17 +163,35 @@
 - name: 'Slicer extensions installed'
   become: true
   become_user: exouser
-  # Slicer's exit code is unreliable, so success is detected by grepping the output
-  # for the marker the script prints ONLY on success. A failed/hung extension (no
-  # marker) makes grep -- and therefore this task -- fail, which stops the loop and
-  # fails setup fast instead of silently continuing or hanging until the timeout.
+  # Success is detected by grepping the output for the marker the script prints
+  # ONLY on success (Slicer's exit code is unreliable). An individual extension
+  # failing is NON-FATAL: failed_when:false keeps the loop going, so one broken
+  # or missing extension (often a transient or server-side packaging issue) does
+  # not block provisioning the whole instance. Failures are collected and
+  # reported below, and surfaced on the GitHub issue by the workflow.
   shell: |
     out=$(timeout -k 30 600 {{ slicer_install_dir }}/Slicer/Slicer --disable-modules --python-script {{ support_install_dir }}/dist/slicer-install-extension.py "{{ item }}" 2>&1)
     printf '%s\n' "$out"
     printf '%s\n' "$out" | grep -q 'SLICER_EXTENSION_INSTALL_OK'
   loop: '{{ slicer_extensions }}'
+  register: slicer_extension_results
+  failed_when: false
   environment:
     DISPLAY: :1.0
+
+- name: 'Collect Slicer extensions that failed to install'
+  set_fact:
+    slicer_failed_extensions: >-
+      {{ slicer_extension_results.results
+         | selectattr('rc', 'defined') | selectattr('rc', 'ne', 0)
+         | map(attribute='item') | list }}
+
+- name: 'Report failed Slicer extensions (non-fatal) to the serial console'
+  become: true
+  shell: >
+    echo 'SLICER_EXTENSIONS_FAILED: {{ slicer_failed_extensions | join(", ") }}'
+    | tee --append /dev/console > /dev/kmsg || true
+  when: slicer_failed_extensions | length > 0
 
 - name: 'File "slicer-install-extension-dependencies.py" copied'
   copy:

--- a/ansible/roles/slicer/tasks/main.yml
+++ b/ansible/roles/slicer/tasks/main.yml
@@ -186,7 +186,15 @@
          | selectattr('rc', 'defined') | selectattr('rc', 'ne', 0)
          | map(attribute='item') | list }}
 
-- name: 'Report failed Slicer extensions (non-fatal) to the serial console'
+- name: 'Record failed Slicer extensions for the completion status line'
+  become: true
+  copy:
+    content: "{{ slicer_failed_extensions | join(', ') }}"
+    dest: "{{ support_install_dir }}/slicer_failed_extensions"
+    mode: "0644"
+  when: slicer_failed_extensions | length > 0
+
+- name: 'Log failed Slicer extensions (non-fatal) to the serial console'
   become: true
   shell: >
     echo 'SLICER_EXTENSIONS_FAILED: {{ slicer_failed_extensions | join(", ") }}'


### PR DESCRIPTION
An extension that fails to install (often a transient or server-side packaging issue on the Slicer extensions catalog — e.g. a duplicate build, as just happened with MorphoDepot for r34621) should **not** block provisioning the whole instance.

- The extensions loop runs `failed_when: false`, so one failed extension doesn't stop the loop.
- Failed extension names are collected and written to `{{ support_install_dir }}/slicer_failed_extensions`, which the `cloud-config` completion line reads so the list reaches the workflow as reliably as the `complete` status itself.
- Remaining extensions, the dependency install, and the rest of setup still run. The **deps** task stays fail-fast (that's the Python environment, not an optional extension).

Pairs with the MorphoCloudWorkflow PR that posts a ⚠️ comment on the issue listing the skipped extension(s). Live-tested on Test-Instances against the currently-broken MorphoDepot.