### PR TITLE
Upgrade Slicer to 5.12.1

### DIFF
--- a/ansible/roles/slicer/vars/main.yml
+++ b/ansible/roles/slicer/vars/main.yml
@@ -7,12 +7,12 @@ slicer_install_dir: "/media/volume/MyData"
 slicer_version:
   major: 5
   minor: 12
-  patch: 0
+  patch: 1
 
 slicer_python_version: 3.12
 
 # slicer_release_id: "{{ slicer_version['major'] }}.{{ slicer_version['minor'] }}.{{ slicer_version['patch'] }}"
-slicer_release_id: "34621"
+slicer_release_id: "34624"
 
 slicer_extensions:
   - SlicerMorph


### PR DESCRIPTION
Bumps 3D Slicer from **5.12.0** to the **5.12.1** patch release (out last week).

Two coupled changes in `ansible/roles/slicer/vars/main.yml`:
- `slicer_version.patch` `0` → `1` — the join app reads this block live to show "3D Slicer 5.12.x" on the morphocloud.org dashboard.
- `slicer_release_id` `"34621"` → `"34624"` — this is what `slicer-download.sh -r` actually downloads. Confirmed on the Slicer package server: `Slicer_linux_amd64_34624` = version 5.12.1. Bumping `patch` without this would still install 5.12.0.

Targets the `morpho-cloud-portal-2026.06-ubuntu24-prep` image-prep branch (same branch that landed the 5.12.0 upgrade in #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)